### PR TITLE
Fix HackAI header link

### DIFF
--- a/src/components/Header/HeaderLinks.js
+++ b/src/components/Header/HeaderLinks.js
@@ -39,9 +39,9 @@ export default function HeaderLinks(props) {
             <Link to="/aim" className={classes.dropdownLink}>
               AIM
             </Link>,
-            <Link to="/hackai" className={classes.dropdownLink}>
+            <a href="https://hackai.org/" className={classes.dropdownLink}>
               HackAI
-            </Link>,
+            </a>,
             <Link to="/concepts" className={classes.dropdownLink}>
               Concepts
             </Link>,


### PR DESCRIPTION
Closes #25

# Summary of Changes
- Changed HackAI link under Divisions to redirect to the official HackAI website.